### PR TITLE
Add option to keep blank lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const pathRegex = /^(?:(?:(?:node|(?:internal\/[\w/]*|.*node_modules\/babel-poly
 const homeDir = os.homedir();
 
 module.exports = (stack, options) => {
-	options = Object.assign({pretty: false}, options);
+	options = Object.assign({pretty: false, keepEmptyLines: false}, options);
 
 	return stack.replace(/\\/g, '/')
 		.split('\n')
@@ -26,7 +26,12 @@ module.exports = (stack, options) => {
 
 			return !pathRegex.test(match);
 		})
-		.filter(x => x.trim() !== '')
+		.filter(x => {
+			if (options.keepEmptyLines) {
+				return true;
+			}
+			return x.trim() !== '';
+		})
 		.map(x => {
 			if (options.pretty) {
 				return x.replace(extractPathRegex, (m, p1) => m.replace(p1, p1.replace(homeDir, '~')));

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,13 @@ Prettify the file paths in the stack:
 
 `/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → `~/dev/clean-stack/unicorn.js:2:15`
 
+##### keepEmptyLines
+
+Type: `boolean`<br>
+Default: `false`
+
+Don't remove existent blank lines
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -128,3 +128,20 @@ test('pretty option', t => {
 	const expected = 'Error: foo\n    at Test.fn (~/dev/clean-stack/test.js:6:15)';
 	t.is(m(stack, {pretty: true}), expected);
 });
+
+test('keepEmptyLines option', t => {
+	const stack = `\nError: foo
+
+    at Test.fn (${os.homedir()}/dev/clean-stack/test.js:6:15)
+    at handleMessage (internal/child_process.js:695:10)
+    at Pipe.channel.onread (internal/child_process.js:440:11)
+    at process.emit (events.js:172:7)
+
+`;
+	const expected = `\nError: foo
+
+    at Test.fn (${os.homedir()}/dev/clean-stack/test.js:6:15)
+
+`;
+	t.is(m(stack, {keepEmptyLines: true}), expected);
+});


### PR DESCRIPTION
When the stacktrace is part of a larger string (for instance captured `console.log`s with traces) it's sometimes useful to keep around empty lines.