### PR TITLE
feat: accept only string or undefined as parameter of stack

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ console.log(cleanStack(error.stack));
 ```
 */
 declare function cleanStack(
-	stack: string,
+	stack?: string,
 	options?: cleanStack.Options
 ): string;
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const homeDir = typeof os.homedir === 'undefined' ? '' : os.homedir();
 
 module.exports = (stack, options) => {
 	if (!stack || typeof stack !== 'string') {
-		return void(0);
+		return undefined;
 	}
 
 	options = Object.assign({pretty: false}, options);

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ const pathRegex = /^(?:(?:(?:node|(?:internal\/[\w/]*|.*node_modules\/(?:babel-p
 const homeDir = typeof os.homedir === 'undefined' ? '' : os.homedir();
 
 module.exports = (stack, options) => {
+	if (!stack || typeof stack !== 'string') {
+		return void(0);
+	}
+
 	options = Object.assign({pretty: false}, options);
 
 	return stack.replace(/\\/g, '/')

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ cleanStack(error.stack) // undefined;
 
 Type: `string | undefined`
 
-The `stack` property of an [`Error`](https://github.com/microsoft/TypeScript/blob/master/lib/lib.es5.d.ts#L972).
+The `stack` property of an [`Error`](https://github.com/microsoft/TypeScript/blob/eac073894b172ec719ca7f28b0b94fc6e6e7d4cf/lib/lib.es5.d.ts#L972-L976).
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,12 @@ console.log(cleanStack(error.stack));
 Error: Missing unicorn
     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15)
 */
+
+// If stack is undefiend or not a string
+const errorWithUndefiendStack = new Error();
+delete errorWithUndefiendStack.stack;
+
+cleanStack(error.stack) // undefined;
 ```
 
 
@@ -47,9 +53,9 @@ Error: Missing unicorn
 
 #### stack
 
-Type: `string`
+Type: `string | undefined`
 
-The `stack` property of an `Error`.
+The `stack` property of an [`Error`](https://github.com/microsoft/TypeScript/blob/master/lib/lib.es5.d.ts#L972).
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -136,3 +136,15 @@ test('pretty option', t => {
 	const expected = 'Error: foo\n    at Test.fn (~/dev/clean-stack/test.js:6:15)';
 	t.is(cleanStack(stack, {pretty: true}), expected);
 });
+
+test('handle undefine', t => {
+	const stack = undefined;
+	const expected = undefined;
+	t.is(cleanStack(stack, {pretty: true}), expected);
+});
+
+test('handle not string', t => {
+	const stack = {};
+	const expected = undefined;
+	t.is(cleanStack(stack, {pretty: true}), expected);
+});


### PR DESCRIPTION
interface Error {
    name: string;
    message: string;
    stack?: string;
}