### PR TITLE
Add `basePath` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare namespace cleanStack {
 		@default false
 		*/
 		readonly pretty?: boolean;
+		readonly basePath?: string;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,15 @@ declare namespace cleanStack {
 		@default false
 		*/
 		readonly pretty?: boolean;
+		/**
+		Removes `basePath` from file paths, effectively turning absolute paths into relative ones.
+
+		Example with `'/Users/sindresorhus/dev/clean-stack/'` as `basePath`:
+
+		`/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → `unicorn.js:2:15`
+
+		@default undefined
+		*/
 		readonly basePath?: string;
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,13 +9,11 @@ declare namespace cleanStack {
 		*/
 		readonly pretty?: boolean;
 		/**
-		Removes `basePath` from file paths, effectively turning absolute paths into relative ones.
+		Remove the given base path from stack trace file paths, effectively turning absolute paths into relative ones.
 
 		Example with `'/Users/sindresorhus/dev/clean-stack/'` as `basePath`:
 
 		`/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → `unicorn.js:2:15`
-
-		@default undefined
 		*/
 		readonly basePath?: string;
 	}

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ module.exports = (stack, options) => {
 		})
 		.filter(line => line.trim() !== '')
 		.map(line => {
-			if (basePathRe) {
-				line = line.replace(basePathRe, (_, p1) => p1);
+			if (basePathRegex) {
+				line = line.replace(basePathRegex, (_, p1) => p1);
 			}
 
 			if (options.pretty) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = (stack, options) => {
 
 	let basePathRe;
 	if (options.basePath) {
-		basePathRe = new RegExp(escapeStringRegexp(options.basePath), 'g');
+		basePathRe = new RegExp(`(at | \\()${escapeStringRegexp(options.basePath)}`, 'g');
 	}
 
 	return stack.replace(/\\/g, '/')
@@ -37,7 +37,7 @@ module.exports = (stack, options) => {
 		.filter(line => line.trim() !== '')
 		.map(line => {
 			if (basePathRe) {
-				line = line.replace(basePathRe, '');
+				line = line.replace(basePathRe, (_, p1) => p1);
 			}
 
 			if (options.pretty) {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const pathRegex = /^(?:(?:(?:node|(?:internal\/[\w/]*|.*node_modules\/(?:babel-p
 const homeDir = typeof os.homedir === 'undefined' ? '' : os.homedir();
 
 module.exports = (stack, options) => {
-	options = Object.assign({pretty: false, basePath: undefined}, options);
+	options = Object.assign({pretty: false}, options);
 
 	const basePathRegex = options.basePath && new RegExp(`(at | \\()${escapeStringRegexp(options.basePath)}`, 'g');
 

--- a/index.js
+++ b/index.js
@@ -9,10 +9,7 @@ const homeDir = typeof os.homedir === 'undefined' ? '' : os.homedir();
 module.exports = (stack, options) => {
 	options = Object.assign({pretty: false, basePath: undefined}, options);
 
-	let basePathRe;
-	if (options.basePath) {
-		basePathRe = new RegExp(`(at | \\()${escapeStringRegexp(options.basePath)}`, 'g');
-	}
+	const basePathRegex = options.basePath && new RegExp(`(at | \\()${escapeStringRegexp(options.basePath)}`, 'g');
 
 	return stack.replace(/\\/g, '/')
 		.split('\n')

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = (stack, options) => {
 		.filter(line => line.trim() !== '')
 		.map(line => {
 			if (basePathRegex) {
-				line = line.replace(basePathRegex, (_, p1) => p1);
+				line = line.replace(basePathRegex, '$1');
 			}
 
 			if (options.pretty) {

--- a/index.js
+++ b/index.js
@@ -36,12 +36,12 @@ module.exports = (stack, options) => {
 		})
 		.filter(line => line.trim() !== '')
 		.map(line => {
-			if (options.pretty) {
-				line = line.replace(extractPathRegex, (m, p1) => m.replace(p1, p1.replace(homeDir, '~')));
-			}
-
 			if (basePathRe) {
 				line = line.replace(basePathRe, '');
+			}
+
+			if (options.pretty) {
+				line = line.replace(extractPathRegex, (m, p1) => m.replace(p1, p1.replace(homeDir, '~')));
 			}
 
 			return line;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,4 +6,5 @@ const error = new Error('Missing unicorn');
 if (error.stack) {
 	expectType<string>(cleanStack(error.stack));
 	expectType<string>(cleanStack(error.stack, {pretty: true}));
+	expectType<string>(cleanStack(error.stack, {basePath: __dirname}));
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
 		"err",
 		"electron"
 	],
+	"dependencies": {
+		"escape-string-regexp": "4.0.0"
+	},
 	"devDependencies": {
 		"ava": "^1.4.1",
 		"tsd": "^0.7.2",

--- a/readme.md
+++ b/readme.md
@@ -66,8 +66,7 @@ Prettify the file paths in the stack:
 
 ##### basePath
 
-Type: `string`<br>
-Default: `undefined`
+Type: `string?`
 
 Remove the given base path from stack trace file paths, effectively turning absolute paths into relative ones.
 

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,17 @@ Prettify the file paths in the stack:
 
 `/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → `~/dev/clean-stack/unicorn.js:2:15`
 
+##### basePath
+
+Type: `string`<br>
+Default: `undefined`
+
+Remove all occurences of `basePath`. Useful for removing absolute paths.
+
+Example with `'/Users/sindresorhus/dev/clean-stack/'` as `basePath`:
+
+`/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → `unicorn.js:2:15`
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Prettify the file paths in the stack:
 Type: `string`<br>
 Default: `undefined`
 
-Removes `basePath` from file paths, effectively turning absolute paths into relative ones.
+Remove the given base path from stack trace file paths, effectively turning absolute paths into relative ones.
 
 Example with `'/Users/sindresorhus/dev/clean-stack/'` as `basePath`:
 

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Prettify the file paths in the stack:
 Type: `string`<br>
 Default: `undefined`
 
-Remove all occurences of `basePath`. Useful for removing absolute paths.
+Removes `basePath` from file paths, effectively turning absolute paths into relative ones.
 
 Example with `'/Users/sindresorhus/dev/clean-stack/'` as `basePath`:
 

--- a/test.js
+++ b/test.js
@@ -152,7 +152,7 @@ test('basePath option', t => {
 	t.is(cleanStack(stack, {basePath}), expected);
 });
 
-test('basePath should have precedence over pretty', t => {
+test('`basePath` option should have precedence over `pretty` option', t => {
 	const basePath = `${os.homedir()}/dev/`;
 	const stack = `Error: with basePath
     at Object.<anonymous> (${os.homedir()}/dev/node_modules/foo/bar.js:1:14)

--- a/test.js
+++ b/test.js
@@ -151,3 +151,18 @@ test('basePath option', t => {
 	const expected = 'Error: with basePath\n    at Object.<anonymous> (node_modules/foo/bar.js:1:14)';
 	t.is(cleanStack(stack, {basePath}), expected);
 });
+
+test('basePath should have precedence over pretty', t => {
+	const basePath = `${os.homedir()}/dev/`;
+	const stack = `Error: with basePath
+    at Object.<anonymous> (${os.homedir()}/dev/node_modules/foo/bar.js:1:14)
+    at Module._compile (internal/modules/cjs/loader.js:1200:30)
+    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
+    at Module.load (internal/modules/cjs/loader.js:1049:32)
+    at Function.Module._load (internal/modules/cjs/loader.js:937:14)
+    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
+    at internal/main/run_main_module.js:17:47`;
+
+	const expected = 'Error: with basePath\n    at Object.<anonymous> (node_modules/foo/bar.js:1:14)';
+	t.is(cleanStack(stack, {basePath, pretty: true}), expected);
+});

--- a/test.js
+++ b/test.js
@@ -136,3 +136,18 @@ test('pretty option', t => {
 	const expected = 'Error: foo\n    at Test.fn (~/dev/clean-stack/test.js:6:15)';
 	t.is(cleanStack(stack, {pretty: true}), expected);
 });
+
+test('basePath option', t => {
+	const basePath = '/Users/foo/dev/';
+	const stack = `Error: with basePath
+    at Object.<anonymous> (/Users/foo/dev/node_modules/foo/bar.js:1:14)
+    at Module._compile (internal/modules/cjs/loader.js:1200:30)
+    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
+    at Module.load (internal/modules/cjs/loader.js:1049:32)
+    at Function.Module._load (internal/modules/cjs/loader.js:937:14)
+    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
+    at internal/main/run_main_module.js:17:47`;
+
+	const expected = 'Error: with basePath\n    at Object.<anonymous> (node_modules/foo/bar.js:1:14)';
+	t.is(cleanStack(stack, {basePath}), expected);
+});

--- a/test.js
+++ b/test.js
@@ -127,7 +127,7 @@ test('works with Electron stack traces - built app', t => {
 	t.is(cleanStack(stack), expected);
 });
 
-test('pretty option', t => {
+test('`pretty` option', t => {
 	const stack = `Error: foo\n
     at Test.fn (${os.homedir()}/dev/clean-stack/test.js:6:15)\n
     at handleMessage (internal/child_process.js:695:10)\n
@@ -141,6 +141,7 @@ test('`basePath` option', t => {
 	const basePath = '/Users/foo/dev/';
 	const stack = `Error: with basePath
     at Object.<anonymous> (/Users/foo/dev/node_modules/foo/bar.js:1:14)
+    at /Users/foo/dev/node_modules/foo/baz.js:1:14
     at Module._compile (internal/modules/cjs/loader.js:1200:30)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
     at Module.load (internal/modules/cjs/loader.js:1049:32)
@@ -148,7 +149,7 @@ test('`basePath` option', t => {
     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
     at internal/main/run_main_module.js:17:47`;
 
-	const expected = 'Error: with basePath\n    at Object.<anonymous> (node_modules/foo/bar.js:1:14)';
+	const expected = 'Error: with basePath\n    at Object.<anonymous> (node_modules/foo/bar.js:1:14)\n    at node_modules/foo/baz.js:1:14';
 	t.is(cleanStack(stack, {basePath}), expected);
 });
 

--- a/test.js
+++ b/test.js
@@ -137,7 +137,7 @@ test('pretty option', t => {
 	t.is(cleanStack(stack, {pretty: true}), expected);
 });
 
-test('basePath option', t => {
+test('`basePath` option', t => {
 	const basePath = '/Users/foo/dev/';
 	const stack = `Error: with basePath
     at Object.<anonymous> (/Users/foo/dev/node_modules/foo/bar.js:1:14)


### PR DESCRIPTION
Decided to implement https://github.com/sindresorhus/clean-stack/issues/17 as it'd be rather useful to have the ability to convert irrelevant absolute paths in stack traces to relative ones. It also gives me a tiny security benefit of not having to reveal absolute paths.

The implementation is basically a string replacement, no path resolution is attempted and trailing slash handling is also left to the user. In the simplest use case, one would specify `basePath: __dirname` in a file in the project root to get all paths below it trimmed.

`basePath` is applied before `pretty` because it yields shorter paths which should be preferred (unless the user runs the script inside their home directory).