### PR TITLE
Fix Node.js 15 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const os = require('os');
 const escapeStringRegexp = require('escape-string-regexp');
 
 const extractPathRegex = /\s+at.*[(\s](.*)\)?/;
-const pathRegex = /^(?:(?:(?:node|(?:internal\/[\w/]*|.*node_modules\/(?:babel-polyfill|pirates)\/.*)?\w+)\.js:\d+:\d+)|native)/;
+const pathRegex = /^(?:(?:(?:node|(?:(?:node:)?internal\/[\w/]*|.*node_modules\/(?:babel-polyfill|pirates)\/.*)?\w+)(?:\.js)?:\d+:\d+)|native)/;
 const homeDir = typeof os.homedir === 'undefined' ? '' : os.homedir();
 
 module.exports = (stack, {pretty = false, basePath} = {}) => {

--- a/test.js
+++ b/test.js
@@ -167,3 +167,21 @@ test('`basePath` option should have precedence over `pretty` option', t => {
 	const expected = 'Error: with basePath\n    at Object.<anonymous> (node_modules/foo/bar.js:1:14)';
 	t.is(cleanStack(stack, {basePath, pretty: true}), expected);
 });
+
+test('new stack format on Node.js>=15', t => {
+	const stack = `Error
+    at B (/home/fengkx/projects/test/stack.js:5:19)
+    at A (/home/fengkx/projects/test/stack.js:7:9)
+    at Object.<anonymous> (/home/fengkx/projects/test/stack.js:14:1)
+    at Module._compile (node:internal/modules/cjs/loader:1099:14)
+    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1131:10)
+    at Module.load (node:internal/modules/cjs/loader:967:32)
+    at Function.Module._load (node:internal/modules/cjs/loader:807:14)
+    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
+    at node:internal/main/run_main_module:17:47`;
+	const expected = `Error
+    at B (/home/fengkx/projects/test/stack.js:5:19)
+    at A (/home/fengkx/projects/test/stack.js:7:9)
+    at Object.<anonymous> (/home/fengkx/projects/test/stack.js:14:1)`;
+	t.is(cleanStack(stack), expected);
+});

--- a/test.js
+++ b/test.js
@@ -168,7 +168,7 @@ test('`basePath` option should have precedence over `pretty` option', t => {
 	t.is(cleanStack(stack, {basePath, pretty: true}), expected);
 });
 
-test('new stack format on Node.js>=15', t => {
+test('new stack format on Node.js 15 and later', t => {
 	const stack = `Error
     at B (/home/fengkx/projects/test/stack.js:5:19)
     at A (/home/fengkx/projects/test/stack.js:7:9)


### PR DESCRIPTION
The stack format has change in Node15(I am testing on v15.2.0)
RunKit example: https://runkit.com/embed/ufcx3dgrynne
Two changes:
1. `node:` is added before `interal`
2. tailing `.js` is removed

Exmaple:
```js
	at Module._compile (internal/modules/cjs/loader.js:1063:30) // node 14
	at Module._compile (node:internal/modules/cjs/loader:1099:14) // node 15
```