### PR TITLE
Remove Electron stack trace on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,9 @@ export default function cleanStack(stack, {pretty = false, basePath} = {}) {
 			// Electron
 			if (
 				match.includes('.app/Contents/Resources/electron.asar') ||
-				match.includes('.app/Contents/Resources/default_app.asar')
+				match.includes('.app/Contents/Resources/default_app.asar') ||
+				match.includes("node_modules/electron/dist/resources/electron.asar") ||
+				match.includes("node_modules/electron/dist/resources/default_app.asar")
 			) {
 				return false;
 			}

--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ export default function cleanStack(stack, {pretty = false, basePath} = {}) {
 			if (
 				match.includes('.app/Contents/Resources/electron.asar') ||
 				match.includes('.app/Contents/Resources/default_app.asar') ||
-				match.includes("node_modules/electron/dist/resources/electron.asar") ||
-				match.includes("node_modules/electron/dist/resources/default_app.asar")
+				match.includes('node_modules/electron/dist/resources/electron.asar') ||
+				match.includes('node_modules/electron/dist/resources/default_app.asar')
 			) {
 				return false;
 			}


### PR DESCRIPTION
* Removes Electron stack traces on Windows (Current implementation only works with mac),

* Tested with: Electron 18.2.0 + Electron Builder 23.0.8 on Windows 11 
