### PR TITLE
Thunkify homeDirectory lookup

### DIFF
--- a/home-directory-browser.js
+++ b/home-directory-browser.js
@@ -1,3 +1,3 @@
-const homeDirectory = '';
+const getHomeDirectory = () => '';
 
-export default homeDirectory;
+export default getHomeDirectory;

--- a/home-directory.js
+++ b/home-directory.js
@@ -1,5 +1,5 @@
 import os from 'node:os';
 
-const homeDirectory = os.homedir().replace(/\\/g, '/');
+const getHomeDirectory = () => os.homedir().replace(/\\/g, '/');
 
-export default homeDirectory;
+export default getHomeDirectory;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import escapeStringRegexp from 'escape-string-regexp';
-import homeDirectory from '#home-directory';
+import getHomeDirectory from '#home-directory';
 
 const extractPathRegex = /\s+at.*[(\s](.*)\)?/;
 const pathRegex = /^(?:(?:(?:node|node:[\w/]+|(?:(?:node:)?internal\/[\w/]*|.*node_modules\/(?:babel-polyfill|pirates)\/.*)?\w+)(?:\.js)?:\d+:\d+)|native)/;
@@ -40,7 +40,7 @@ export default function cleanStack(stack, {pretty = false, basePath} = {}) {
 			}
 
 			if (pretty) {
-				line = line.replace(extractPathRegex, (m, p1) => m.replace(p1, p1.replace(homeDirectory, '~')));
+				line = line.replace(extractPathRegex, (m, p1) => m.replace(p1, p1.replace(getHomeDirectory(), '~')));
 			}
 
 			return line;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const pathRegex = /^(?:(?:(?:node|node:[\w/]+|(?:(?:node:)?internal\/[\w/]*|.*no
 
 export default function cleanStack(stack, {pretty = false, basePath} = {}) {
 	const basePathRegex = basePath && new RegExp(`(file://)?${escapeStringRegexp(basePath.replace(/\\/g, '/'))}/?`, 'g');
+	const homeDirectory = pretty ? getHomeDirectory() : '';
 
 	if (typeof stack !== 'string') {
 		return undefined;
@@ -40,7 +41,7 @@ export default function cleanStack(stack, {pretty = false, basePath} = {}) {
 			}
 
 			if (pretty) {
-				line = line.replace(extractPathRegex, (m, p1) => m.replace(p1, p1.replace(getHomeDirectory(), '~')));
+				line = line.replace(extractPathRegex, (m, p1) => m.replace(p1, p1.replace(homeDirectory, '~')));
 			}
 
 			return line;

--- a/test.js
+++ b/test.js
@@ -1,5 +1,7 @@
 import os from 'node:os';
 import test from 'ava';
+import getHomeDirectoryNode from './home-directory.js';
+import getHomeDirectoryBrowser from './home-directory-browser.js';
 import cleanStack from './index.js';
 
 test('default', t => {
@@ -269,4 +271,9 @@ test('handle undefined', t => {
 	const stack = undefined;
 	const expected = undefined;
 	t.is(cleanStack(stack, {pretty: true}), expected);
+});
+
+test('exports for home-directory files match', t => {
+	t.is(typeof getHomeDirectoryNode, 'function');
+	t.is(typeof getHomeDirectoryBrowser, 'function');
 });


### PR DESCRIPTION
If `pretty === false`, do not invoke `os.homedir()`.

I reason calls to `os.*` should only occur when the user configures behavior provided by this library that require them.