### PR TITLE
Creates an optional callback to check for other paths to omit

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,11 +18,9 @@ export type Options = {
 	readonly basePath?: string;
 
 	/**
-	Remove any stack lines where their paths return false from this callback.
+	Remove the stack lines where the given function returns `false`. The function receives the path part of the stack line.
 
-  Example with `path => /unicorn/.test(path)` as `pathFilterCallback`:
-
-	```js
+	```
 	import cleanStack from 'clean-stack';
 
 	const error = new Error('Missing unicorn');
@@ -37,7 +35,7 @@ export type Options = {
 	console.log(cleanStack(error.stack, {pathFilter}));
 	// Error: Missing unicorn
 	//     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15)
-  ```
+	```
 	*/
 	readonly pathFilter?: (path: string) => boolean;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,13 +18,28 @@ export type Options = {
 	readonly basePath?: string;
 
 	/**
-	Remove any paths that return false from this callback.
+	Remove any stack lines where their paths return false from this callback.
 
   Example with `path => /unicorn/.test(path)` as `pathFilterCallback`:
 
-	`/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → ``
+	```js
+	import cleanStack from 'clean-stack';
+
+	const error = new Error('Missing unicorn');
+
+	console.log(cleanStack(error.stack));
+	// Error: Missing unicorn
+	//     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15)
+	//     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/omit-me.js:1:16)
+
+	const pathFilter = path => /omit-me/.test(path);
+
+	console.log(cleanStack(error.stack, {pathFilter}));
+	// Error: Missing unicorn
+	//     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15)
+  ```
 	*/
-	readonly pathFilterCallback?: (path: string) => boolean;
+	readonly pathFilter?: (path: string) => boolean;
 };
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ export type Options = {
 
 	`/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → ``
 	*/
-	readonly pathFilterCallback?: (string) => boolean;
+	readonly pathFilterCallback?: (path: string) => boolean;
 };
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,9 +18,13 @@ export type Options = {
 	readonly basePath?: string;
 
 	/**
-	Remove any paths that match this regexp from the stack.
+	Remove any paths that return false from this callback.
+
+  Example with `path => /unicorn/.test(path)` as `pathFilterCallback`:
+
+	`/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → ``
 	*/
-	readonly extraPathRegex?: RegExp;
+	readonly pathFilterCallback?: (string) => boolean;
 };
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export type Options = {
 	/**
 	Remove the stack lines where the given function returns `false`. The function receives the path part of the stack line.
 
+	@example
 	```
 	import cleanStack from 'clean-stack';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,11 @@ export type Options = {
 	`/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → `unicorn.js:2:15`
 	*/
 	readonly basePath?: string;
+
+	/**
+	Remove any paths that match this regexp from the stack.
+	*/
+	readonly extraPathRegex?: RegExp;
 };
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,7 @@ export type Options = {
 	//     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15)
 	//     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/omit-me.js:1:16)
 
-	const pathFilter = path => /omit-me/.test(path);
+	const pathFilter = path => !/omit-me/.test(path);
 
 	console.log(cleanStack(error.stack, {pathFilter}));
 	// Error: Missing unicorn

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import getHomeDirectory from '#home-directory';
 const extractPathRegex = /\s+at.*[(\s](.*)\)?/;
 const pathRegex = /^(?:(?:(?:node|node:[\w/]+|(?:(?:node:)?internal\/[\w/]*|.*node_modules\/(?:babel-polyfill|pirates)\/.*)?\w+)(?:\.js)?:\d+:\d+)|native)/;
 
-export default function cleanStack(stack, {pretty = false, basePath} = {}) {
+export default function cleanStack(stack, {pretty = false, basePath, extraPathRegex} = {}) {
 	const basePathRegex = basePath && new RegExp(`(file://)?${escapeStringRegexp(basePath.replace(/\\/g, '/'))}/?`, 'g');
 	const homeDirectory = pretty ? getHomeDirectory() : '';
 
@@ -32,7 +32,9 @@ export default function cleanStack(stack, {pretty = false, basePath} = {}) {
 				return false;
 			}
 
-			return !pathRegex.test(match);
+			return extraPathRegex
+				? !pathRegex.test(match) && !extraPathRegex.test(match)
+				: !pathRegex.test(match);
 		})
 		.filter(line => line.trim() !== '')
 		.map(line => {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import getHomeDirectory from '#home-directory';
 const extractPathRegex = /\s+at.*[(\s](.*)\)?/;
 const pathRegex = /^(?:(?:(?:node|node:[\w/]+|(?:(?:node:)?internal\/[\w/]*|.*node_modules\/(?:babel-polyfill|pirates)\/.*)?\w+)(?:\.js)?:\d+:\d+)|native)/;
 
-export default function cleanStack(stack, {pretty = false, basePath, pathFilterCallback} = {}) {
+export default function cleanStack(stack, {pretty = false, basePath, pathFilter} = {}) {
 	const basePathRegex = basePath && new RegExp(`(file://)?${escapeStringRegexp(basePath.replace(/\\/g, '/'))}/?`, 'g');
 	const homeDirectory = pretty ? getHomeDirectory() : '';
 
@@ -32,8 +32,8 @@ export default function cleanStack(stack, {pretty = false, basePath, pathFilterC
 				return false;
 			}
 
-			return pathFilterCallback
-				? !pathRegex.test(match) && pathFilterCallback(match)
+			return pathFilter
+				? !pathRegex.test(match) && pathFilter(match)
 				: !pathRegex.test(match);
 		})
 		.filter(line => line.trim() !== '')

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import getHomeDirectory from '#home-directory';
 const extractPathRegex = /\s+at.*[(\s](.*)\)?/;
 const pathRegex = /^(?:(?:(?:node|node:[\w/]+|(?:(?:node:)?internal\/[\w/]*|.*node_modules\/(?:babel-polyfill|pirates)\/.*)?\w+)(?:\.js)?:\d+:\d+)|native)/;
 
-export default function cleanStack(stack, {pretty = false, basePath, extraPathRegex} = {}) {
+export default function cleanStack(stack, {pretty = false, basePath, pathFilterCallback} = {}) {
 	const basePathRegex = basePath && new RegExp(`(file://)?${escapeStringRegexp(basePath.replace(/\\/g, '/'))}/?`, 'g');
 	const homeDirectory = pretty ? getHomeDirectory() : '';
 
@@ -32,8 +32,8 @@ export default function cleanStack(stack, {pretty = false, basePath, extraPathRe
 				return false;
 			}
 
-			return extraPathRegex
-				? !pathRegex.test(match) && !extraPathRegex.test(match)
+			return pathFilterCallback
+				? !pathRegex.test(match) && pathFilterCallback(match)
 				: !pathRegex.test(match);
 		})
 		.filter(line => line.trim() !== '')

--- a/readme.md
+++ b/readme.md
@@ -77,11 +77,26 @@ Example with `'/Users/sindresorhus/dev/clean-stack'` as `basePath`:
 
 Type: `(string) => boolean`
 
-Remove any paths that return false from this callback.
+Remove any stack lines where their paths return false from this callback.
 
-Example with `path => /unicorn/.test(path)` as `pathFilterCallback`:
+Example with `path => /omit-me/.test(path)` as `pathFilterCallback`:
 
-`/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → ``
+```js
+import cleanStack from 'clean-stack';
+
+const error = new Error('Missing unicorn');
+
+console.log(cleanStack(error.stack));
+// Error: Missing unicorn
+//     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15)
+//     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/omit-me.js:1:16)
+
+const pathFilter = path => /omit-me/.test(path);
+
+console.log(cleanStack(error.stack, {pathFilter}));
+// Error: Missing unicorn
+//     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15)
+```
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -73,11 +73,15 @@ Example with `'/Users/sindresorhus/dev/clean-stack'` as `basePath`:
 
 `/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → `unicorn.js:2:15`
 
-##### extraPathRegex
+##### pathFilterCallback
 
-Type: `regexp?`
+Type: `(string) => boolean`
 
-Remove any paths that match this regexp from the stack.
+Remove any paths that return false from this callback.
+
+Example with `path => /unicorn/.test(path)` as `pathFilterCallback`:
+
+`/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → ``
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,12 @@ Example with `'/Users/sindresorhus/dev/clean-stack'` as `basePath`:
 
 `/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → `unicorn.js:2:15`
 
+##### extraPathRegex
+
+Type: `regexp?`
+
+Remove any paths that match this regexp from the stack.
+
 ## Related
 
 - [extract-stack](https://github.com/sindresorhus/extract-stack) - Extract the actual stack of an error

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ Example with `'/Users/sindresorhus/dev/clean-stack'` as `basePath`:
 
 ##### pathFilter
 
-Type: `(string) => boolean`
+Type: `(path: string) => boolean`
 
 Remove the stack lines where the given function returns `false`. The function receives the path part of the stack line.
 

--- a/readme.md
+++ b/readme.md
@@ -73,13 +73,11 @@ Example with `'/Users/sindresorhus/dev/clean-stack'` as `basePath`:
 
 `/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15` → `unicorn.js:2:15`
 
-##### pathFilterCallback
+##### pathFilter
 
 Type: `(string) => boolean`
 
-Remove any stack lines where their paths return false from this callback.
-
-Example with `path => /omit-me/.test(path)` as `pathFilterCallback`:
+Remove the stack lines where the given function returns `false`. The function receives the path part of the stack line.
 
 ```js
 import cleanStack from 'clean-stack';

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ console.log(cleanStack(error.stack));
 //     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:2:15)
 //     at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/omit-me.js:1:16)
 
-const pathFilter = path => /omit-me/.test(path);
+const pathFilter = path => !/omit-me/.test(path);
 
 console.log(cleanStack(error.stack, {pathFilter}));
 // Error: Missing unicorn

--- a/test.js
+++ b/test.js
@@ -218,8 +218,8 @@ test('`basePath` option should support file URLs', t => {
 	t.is(cleanStack(stack, {basePath, pretty: true}), expected);
 });
 
-test('`extraPathRegex` option allows for excluding custom lines', t => {
-	const extraPathRegex = /home-directory/;
+test('`pathFilterCallback` option allows for excluding custom lines if the callback returns true', t => {
+	const pathFilterCallback = path => !/home-directory/.test(path);
 
 	const pre = `Error: foo
     at Test.fn (/Users/sindresorhus/dev/clean-stack/test.js:6:15)`;
@@ -232,7 +232,24 @@ test('`extraPathRegex` option allows for excluding custom lines', t => {
     at Pipe.channel.onread (internal/child_process.js:440:11)
     at process.emit (events.js:172:7)`;
 
-	t.is(cleanStack(stack, {extraPathRegex}), pre);
+	t.is(cleanStack(stack, {pathFilterCallback}), pre);
+});
+
+test('`pathFilterCallback` option keeps custom lines if the callback returns false', t => {
+	const pathFilterCallback = () => true;
+
+	const pre = `Error: foo
+    at Test.fn (/Users/sindresorhus/dev/clean-stack/test.js:6:15)
+    at getHomeDirectory (/Users/sindresorhus/dev/clean-stack/home-directory.js:3:32)`;
+
+	const stack = `${pre}\n
+    at MySocket.emit (node:events:365:28)
+    at MySocket.emit (node:fs/promises:363:28)
+    at handleMessage (internal/child_process.js:695:10)
+    at Pipe.channel.onread (internal/child_process.js:440:11)
+    at process.emit (events.js:172:7)`;
+
+	t.is(cleanStack(stack, {pathFilterCallback}), pre);
 });
 
 test('new stack format on Node.js 15 and later', t => {

--- a/test.js
+++ b/test.js
@@ -218,7 +218,7 @@ test('`basePath` option should support file URLs', t => {
 	t.is(cleanStack(stack, {basePath, pretty: true}), expected);
 });
 
-test('`pathFilterCallback` option allows for excluding custom lines if the callback returns true', t => {
+test('`pathFilter` option allows for excluding custom lines if the callback returns true', t => {
 	const pathFilterCallback = path => !/home-directory/.test(path);
 
 	const pre = `Error: foo
@@ -235,7 +235,7 @@ test('`pathFilterCallback` option allows for excluding custom lines if the callb
 	t.is(cleanStack(stack, {pathFilterCallback}), pre);
 });
 
-test('`pathFilterCallback` option keeps custom lines if the callback returns false', t => {
+test('`pathFilter` option keeps custom lines if the callback returns false', t => {
 	const pathFilterCallback = () => true;
 
 	const pre = `Error: foo

--- a/test.js
+++ b/test.js
@@ -218,6 +218,23 @@ test('`basePath` option should support file URLs', t => {
 	t.is(cleanStack(stack, {basePath, pretty: true}), expected);
 });
 
+test('`extraPathRegex` option allows for excluding custom lines', t => {
+	const extraPathRegex = /home-directory/;
+
+	const pre = `Error: foo
+    at Test.fn (/Users/sindresorhus/dev/clean-stack/test.js:6:15)`;
+
+	const stack = `${pre}\n
+		at getHomeDirectory (/Users/sindresorhus/dev/clean-stack/home-directory.js:3:32)
+    at MySocket.emit (node:events:365:28)
+    at MySocket.emit (node:fs/promises:363:28)
+    at handleMessage (internal/child_process.js:695:10)
+    at Pipe.channel.onread (internal/child_process.js:440:11)
+    at process.emit (events.js:172:7)`;
+
+	t.is(cleanStack(stack, {extraPathRegex}), pre);
+});
+
 test('new stack format on Node.js 15 and later', t => {
 	const stack = `Error
     at B (/home/fengkx/projects/test/stack.js:5:19)

--- a/test.js
+++ b/test.js
@@ -219,7 +219,7 @@ test('`basePath` option should support file URLs', t => {
 });
 
 test('`pathFilter` option allows for excluding custom lines if the callback returns true', t => {
-	const pathFilterCallback = path => !/home-directory/.test(path);
+	const pathFilter = path => !/home-directory/.test(path);
 
 	const pre = `Error: foo
     at Test.fn (/Users/sindresorhus/dev/clean-stack/test.js:6:15)`;
@@ -232,7 +232,7 @@ test('`pathFilter` option allows for excluding custom lines if the callback retu
     at Pipe.channel.onread (internal/child_process.js:440:11)
     at process.emit (events.js:172:7)`;
 
-	t.is(cleanStack(stack, {pathFilterCallback}), pre);
+	t.is(cleanStack(stack, {pathFilter}), pre);
 });
 
 test('`pathFilter` option keeps custom lines if the callback returns false', t => {


### PR DESCRIPTION
Love this repo - I think it'd be great if we could omit a few more paths as-needed. 

This PR:

- Adds an option for `pathFilterCallback` which can be used to filter out extra lines if the callback returns false for the line's path.
- Adds a test for this option. 

I'll add to the readme for this option next. Let me know if you have any questions!