### PR TITLE
Make `clean-stack` idempotent

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import getHomeDirectory from '#home-directory';
 
 const extractPathRegex = /\s+at.*[(\s](.*)\)?/;
 const pathRegex = /^(?:(?:(?:node|node:[\w/]+|(?:(?:node:)?internal\/[\w/]*|.*node_modules\/(?:babel-polyfill|pirates)\/.*)?\w+)(?:\.js)?:\d+:\d+)|native)/;
+const simplePathRegex = /^\w+\.js:\d+:\d+$/;
 
 export default function cleanStack(stack, {pretty = false, basePath, pathFilter} = {}) {
 	const basePathRegex = basePath && new RegExp(`(file://)?${escapeStringRegexp(basePath.replace(/\\/g, '/'))}/?`, 'g');
@@ -31,6 +32,10 @@ export default function cleanStack(stack, {pretty = false, basePath, pathFilter}
 				|| match.includes('node_modules/electron/dist/resources/default_app.asar')
 			) {
 				return false;
+			}
+
+			if (simplePathRegex.test(match)) {
+				return true;
 			}
 
 			return pathFilter

--- a/test.js
+++ b/test.js
@@ -31,15 +31,15 @@ test('default #2', t => {
 
 test('directly executed node script', t => {
 	const pre = `Error: foo
-    at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:4:7)`;
+    at Object.<anonymous> (/Users/sindresorhus/dev/clean-stack/unicorn.js:4:7)
+    at node.js:968:3`;
 	const stack = `${pre}\n
     at Module._compile (module.js:409:26)
     at Object.Module._extensions..js (module.js:416:10)
     at Module.load (module.js:343:32)
     at Function.Module._load (module.js:300:12)
     at Function.Module.runMain (module.js:441:10)
-    at startup (node.js:139:18)
-    at node.js:968:3`;
+    at startup (node.js:139:18)`;
 	t.is(cleanStack(stack), pre);
 });
 
@@ -168,6 +168,8 @@ test('`basePath` option', t => {
     at Object.<anonymous> (node_modules/foo/bar.js:1:14)
     at node_modules/foo/baz.js:1:14`;
 	t.is(cleanStack(stack, {basePath}), expected);
+	t.is(cleanStack(cleanStack(stack, {basePath})), expected);
+	t.is(cleanStack(cleanStack(stack, {basePath}), {basePath}), expected);
 });
 
 test('`basePath` option should have precedence over `pretty` option', t => {


### PR DESCRIPTION
`clean-stack` is not always idempotent. This PR fixes it.

The reason is:
  - any stack line that looks like `at file_path.js:1:1` is filtered out
  - but the `basePath` option produces such lines, _providing_ the file is directly in the `basePath` directory (not a subdirectory)

So, when the `basePath` option is used, applying `clean-stack` a second time results in an empty stack trace.

The problem here is: why remove stack lines that look like `at file_path.js:1:1`? It seems like this originated from the following commit 9 years ago: https://github.com/sindresorhus/clean-stack/commit/571de7fe5cce8574df2e971ea30c01f64974cc2d

If I'm not mistaken, it seems like the reason was to remove the `bootstrap_node.js` stack lines that were added by Node.js when executing a shebang file. However, those lines are not produced since Node.js 10.

Another potential reason might be to remove node internals which used to be like: `at Function.Module._load (module.js:300:12)`. However, since Node 10, those are like: `at Function.Module._load (internal/modules/cjs/loader.js:585:3)`. Then since Node 16, the stack shows `node:internal` instead of `internal`. `clean-stack`'s regular expression targets both the `node:` and the `internal` keywords, so there's no need for the above logic then, if that was the reason.